### PR TITLE
chore: update versions and benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 turbo-build.log
 
 .nx/cache
+.nx/workspace-data

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ ordinary. And, the bigger the repo, the bigger the difference in performance bet
 The repo has Nx, Turbo, and Lage enabled. They don't affect each other. You can remove one without affecting the
 other one.
 
-## Benchmark & Results (May 1)
+## Benchmark & Results (February 12th, 2025)
 
-`npm run benchmark` runs the benchmark. The following numbers produced by an M1Max MBP on macOS 13 (Ventura). On a Windows machine all the tools will get slower, and the delta between Nx and Turbo/Lage will get bigger.
+`npm run benchmark` runs the benchmark. The following numbers produced by an M2Max MBP on macOS 14 (Sonoma). On a Windows machine all the tools will get slower, and the delta between Nx and Turbo/Lage will get bigger.
 
 - **average lage time is: 1258.6**
 - **average turbo time is: 1432.4**

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ other one.
 
 `npm run benchmark` runs the benchmark. The following numbers produced by an M1Max MBP on macOS 13 (Ventura). On a Windows machine all the tools will get slower, and the delta between Nx and Turbo/Lage will get bigger.
 
-- **average turbo time is: 633.1**
-- **average lage time is: 395.7**
-- **average nx time is: 153.0**
-- **nx is 2.58x faster than lage**
-- **nx is 4.13x faster than turbo**
+- **average lage time is: 1258.6**
+- **average turbo time is: 1432.4**
+- **average nx time is: 191.7**
+- **nx is 6.57x faster than lage**
+- **nx is 7.47x faster than turbo**
 
 ### Why is Nx faster than Turbo
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -98,5 +98,5 @@ console.log(`average lage time is: ${averageLageTime}`);
 console.log(`average turbo time is: ${averageTurboTime}`);
 console.log(`average nx time is: ${averageNxTime}`);
 
-console.log(`nx is ${averageLageTime / averageNxTime}x faster than lage`);
-console.log(`nx is ${averageTurboTime / averageNxTime}x faster than turbo`);
+console.log(`nx is ${(averageLageTime / averageNxTime).toFixed(2)}x faster than lage`);
+console.log(`nx is ${(averageTurboTime / averageNxTime).toFixed(2)}x faster than turbo`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "packages/*/*"
       ],
       "devDependencies": {
-        "lage": "2.7.14",
-        "nx": "19.0.0-beta.8",
-        "turbo": "1.13.3",
-        "typescript": "4.5.2"
+        "lage": "2.12.19",
+        "nx": "20.5.0-beta.2",
+        "turbo": "2.4.1",
+        "typescript": "5.7.3"
       }
     },
     "apps/crew": {
@@ -51,6 +51,19 @@
         "typescript": "4.5.2"
       }
     },
+    "apps/crew/node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "http://localhost:4873/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "apps/flight-simulator": {
       "version": "1.0.0",
       "dependencies": {
@@ -82,6 +95,19 @@
         "@types/react": "17.0.37",
         "next-transpile-modules": "9.0.0",
         "typescript": "4.5.2"
+      }
+    },
+    "apps/flight-simulator/node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "http://localhost:4873/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "apps/navigation": {
@@ -117,6 +143,19 @@
         "typescript": "4.5.2"
       }
     },
+    "apps/navigation/node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "http://localhost:4873/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "apps/ticket-booking": {
       "version": "1.0.0",
       "dependencies": {
@@ -150,6 +189,19 @@
         "typescript": "4.5.2"
       }
     },
+    "apps/ticket-booking/node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "http://localhost:4873/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "apps/warp-drive-manager": {
       "version": "1.0.0",
       "dependencies": {
@@ -181,6 +233,19 @@
         "@types/react": "17.0.37",
         "next-transpile-modules": "9.0.0",
         "typescript": "4.5.2"
+      }
+    },
+    "apps/warp-drive-manager/node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "http://localhost:4873/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1082,6 +1147,34 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.3.1",
+      "resolved": "http://localhost:4873/@emnapi/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==",
+      "dev": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.3.1",
+      "resolved": "http://localhost:4873/@emnapi/runtime/-/runtime-1.3.1.tgz",
+      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.1",
+      "resolved": "http://localhost:4873/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
+      "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@hapi/accept": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
@@ -1168,6 +1261,17 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.3.tgz",
       "integrity": "sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA=="
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.4",
+      "resolved": "http://localhost:4873/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
+      "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "dev": true,
+      "dependencies": {
+        "@emnapi/core": "^1.1.0",
+        "@emnapi/runtime": "^1.1.0",
+        "@tybys/wasm-util": "^0.9.0"
+      }
     },
     "node_modules/@next/env": {
       "version": "12.0.3",
@@ -1401,23 +1505,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@nrwl/tao": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-19.0.0-beta.8.tgz",
-      "integrity": "sha512-GEQYKfPU1CiCnLdgVHld15oG6rV3WuWjWC1PuUcjK52SHq4AEpGUffEjCKu/xZXjxajXJJ9ILx8JeUjbnmmYAA==",
-      "dev": true,
-      "dependencies": {
-        "nx": "19.0.0-beta.8",
-        "tslib": "^2.3.0"
-      },
-      "bin": {
-        "tao": "index.js"
-      }
-    },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.0.0-beta.8.tgz",
-      "integrity": "sha512-s9q8dKibTWLTZZVVsxTs94hXNkfgKeOq/v6Xz4Q/vXp4K+RHQPziDZ9oYSsm8pfF80wwlMu78DCJZLR99x22aA==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.5.0-beta.2.tgz",
+      "integrity": "sha512-Vj49xasCpD3iCfH6fAgblq9h7tSGCIzFFrKdo0/Wzgkx5Hs4VuZvPcVoDI7tM4sXqb3O1VF89rseFGY4DaKBzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1431,9 +1522,9 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.0.0-beta.8.tgz",
-      "integrity": "sha512-JEOJ86Q9rJf/UVI+mTuOvmWzWuZ3s4H4unfJCpFrsJDRn+P1xldEMLDWaqwOuXOKkIyv/ZH8czKqGMr1z0Yevw==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-darwin-x64/-/nx-darwin-x64-20.5.0-beta.2.tgz",
+      "integrity": "sha512-GyhNoDIS+Nbyv5wj97V5jrC5fXaaVzGgYqx0aqh0LLczv0m87Yc7I+eSuQDtsr9pL5GYEXXiAmYp5o4+RVGjWw==",
       "cpu": [
         "x64"
       ],
@@ -1447,9 +1538,9 @@
       }
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.0.0-beta.8.tgz",
-      "integrity": "sha512-w8OXsK4tdRHPQMU2nLOaLUXSaoGKQZQeasvVe2tRc7ZFLZpXVTRwv6CMLuhmrD3ath0GfE3CWVl7JLKXBL47FQ==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.5.0-beta.2.tgz",
+      "integrity": "sha512-OWZeWsgltgjG7FxzaAZ1n/YDvwb4Dmlxdv2fk69E7BXwOO5t7UGoB3Lqp8gm4yd2iUx3/JwnoVYAiLNTck2CuQ==",
       "cpu": [
         "x64"
       ],
@@ -1463,9 +1554,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.0.0-beta.8.tgz",
-      "integrity": "sha512-5agEQtktr64LzCZBY/9kgnG3fEigWOYOOvLNmh+8v1qSraFiX8+xc0LDIlmr00bAoi4Yq9h2YD05quJLpiMu1g==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.5.0-beta.2.tgz",
+      "integrity": "sha512-zyocSLztvlT87S2lOUIBt+yAOUmq3VZ8Soco/85wmfk4G95h5HTbhvVc74Z9ZBzh16sWwsCx+hF/YAVGf0GhkA==",
       "cpu": [
         "arm"
       ],
@@ -1479,9 +1570,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.0.0-beta.8.tgz",
-      "integrity": "sha512-the6iIHEuI0CXc4afGxDjBQU1W9P3WP5gnBr5pydC3ozjigIl9z4i4Lek0gcjUiOb493/A5YFM/exIK+0eIXbg==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.5.0-beta.2.tgz",
+      "integrity": "sha512-xFuJGxlJDlVD8Ulesy0caZLplj0niZPLlG1D/9A2QeQiKCGSqNBrGB63XWfgj3XG6w5p9mLDEdfap8FQq/jmFg==",
       "cpu": [
         "arm64"
       ],
@@ -1495,9 +1586,9 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.0.0-beta.8.tgz",
-      "integrity": "sha512-BNPtmAUaBwAHZuOzT/0KrsPdESb5kG6LglvlwG42yDM+shCyZGWlzvl/vlG28sOgLdT+wVbR95WzdFdtnCktQg==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.5.0-beta.2.tgz",
+      "integrity": "sha512-VMA0dNj4Tccbqon/QVanjXDwG00BldNwMS9VZegnDfLDb1P+G197TnHO1ka+zwDuhU1DhlLEyj3XTckJucCbXw==",
       "cpu": [
         "arm64"
       ],
@@ -1511,9 +1602,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.0.0-beta.8.tgz",
-      "integrity": "sha512-IOrIrVWUsvN5hZINZJbTcI2KjAyM4ro1/FLOpFp7RpL/uJszrLJuFo1eOImiOjqWpr3iR5lDt1S0wtsLMs003A==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.5.0-beta.2.tgz",
+      "integrity": "sha512-ncD4NoExZ5LDGTTWLtIXHaMOVzm1BRCFkgZTHZ6QYUMP9qTmqXkdLc9M4B7p+s96YXMvmc6fsV/EcG0b1vhNgA==",
       "cpu": [
         "x64"
       ],
@@ -1527,9 +1618,9 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.0.0-beta.8.tgz",
-      "integrity": "sha512-accL6xwIrJQLHphOqzvT9VlH9Gsr8cCoyJJpXhpYGBHWIkpLDM2GcB/0Z+qEFrzlDEi36yCqBbc5HahLvJ+Geg==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.5.0-beta.2.tgz",
+      "integrity": "sha512-VT9dsVJRz1A7JjjZ6niWyVV4Gd4JI9vqXjOO7JdKMhAEGG/l2vHBFWFftboClLp34AFa636c22OttUddmGWCzg==",
       "cpu": [
         "x64"
       ],
@@ -1543,9 +1634,9 @@
       }
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.0.0-beta.8.tgz",
-      "integrity": "sha512-fhhGlzzThh7BIq5tVHFEHL11pfOzTJXqU7q9EYkro88qwQIKynkTthtU+8vuQzBVjldbpDpgIFUwecTQXrbnfQ==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.5.0-beta.2.tgz",
+      "integrity": "sha512-B1Dy4EBGI6QEHmhPXSDkmw1EzMag5vSrUZtoUscGf0ugRpEF8pYkcPdF24NJRmXfXzYNEve0el2QPTNoXPStdA==",
       "cpu": [
         "arm64"
       ],
@@ -1559,9 +1650,9 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.0.0-beta.8.tgz",
-      "integrity": "sha512-4DndNYohpWE0fhIUVLm91cZ3HQPN1utH7c1i2/5A3Osg1zoXk/fUM4GtxQOVqmgwuMaRGXtUTGC+LLnrPG2hUg==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.5.0-beta.2.tgz",
+      "integrity": "sha512-/2RINW9OJ9IHy4Gi9gVcZ2DTMkjLwZf6NZjdSB0p4+v3W8FAAH1EJyHMSJk62Rqu0fl0dfVcCiWCENeZG0JZ5A==",
       "cpu": [
         "x64"
       ],
@@ -1579,6 +1670,15 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "resolved": "http://localhost:4873/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
+      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.10.0",
@@ -1618,44 +1718,22 @@
       "dev": true
     },
     "node_modules/@yarnpkg/parsers": {
-      "version": "3.0.0-rc.46",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.46.tgz",
-      "integrity": "sha512-aiATs7pSutzda/rq8fnuPwTglyVwjM22bNnK2ZgjrpAjQHSSl3lztd2f9evst1W/qnC58DRz7T7QndUDumAR4Q==",
+      "version": "3.0.2",
+      "resolved": "http://localhost:4873/@yarnpkg/parsers/-/parsers-3.0.2.tgz",
+      "integrity": "sha512-/HcYgtUSiJiot/XWGLOlGxPYUG65+/31V8oqk17vZLW1xlCoR4PampyePljOxY2n8/3jz9+tIFzICsyGujJZoA==",
       "dev": true,
       "dependencies": {
         "js-yaml": "^3.10.0",
         "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=14.15.0"
-      }
-    },
-    "node_modules/@yarnpkg/parsers/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "node": ">=18.12.0"
       }
     },
     "node_modules/@zkochan/js-yaml": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
-      "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
+      "version": "0.0.7",
+      "resolved": "http://localhost:4873/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz",
+      "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
@@ -1725,7 +1803,7 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "resolved": "http://localhost:4873/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
@@ -1758,7 +1836,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "http://localhost:4873/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
@@ -1774,12 +1852,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.7.9",
+      "resolved": "http://localhost:4873/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -2153,7 +2231,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "http://localhost:4873/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "dependencies": {
@@ -2442,7 +2520,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "http://localhost:4873/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "engines": {
@@ -2502,31 +2580,31 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.7",
+      "resolved": "http://localhost:4873/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
-      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "version": "11.0.7",
+      "resolved": "http://localhost:4873/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
       "dev": true,
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.595",
@@ -2631,7 +2709,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "http://localhost:4873/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "bin": {
@@ -2815,9 +2893,9 @@
       "link": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.9",
+      "resolved": "http://localhost:4873/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "dev": true,
       "funding": [
         {
@@ -2843,9 +2921,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.1",
+      "resolved": "http://localhost:4873/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -2856,25 +2934,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/front-matter": {
+      "version": "4.0.2",
+      "resolved": "http://localhost:4873/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.13.1"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
-    },
-    "node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2961,25 +3034,25 @@
       }
     },
     "node_modules/glob-hasher": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/glob-hasher/-/glob-hasher-1.3.0.tgz",
-      "integrity": "sha512-kwtzRkuYcF1FfO5h7rwMtklwI2wtAXh4BreHxgSSvoFQ4XGdtIIxkXUEmmvIsCrVr2NVBSNyCmcCXxkddtUv9w==",
+      "version": "1.4.2",
+      "resolved": "http://localhost:4873/glob-hasher/-/glob-hasher-1.4.2.tgz",
+      "integrity": "sha512-wYeJvOixB9iAzNpY94AgK0JvOdOQ7g30U+PN0LGSH9u0Y0WC+jIwukjMZ1JZiSoNzUSyrvABZYCNhXpZEoJ/8Q==",
       "dev": true,
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "glob-hasher-darwin-arm64": "1.3.0",
-        "glob-hasher-darwin-x64": "1.3.0",
-        "glob-hasher-linux-x64-gnu": "1.3.0",
-        "glob-hasher-win32-arm64-msvc": "1.3.0",
-        "glob-hasher-win32-x64-msvc": "1.3.0"
+        "glob-hasher-darwin-arm64": "1.4.2",
+        "glob-hasher-darwin-x64": "1.4.2",
+        "glob-hasher-linux-x64-gnu": "1.4.2",
+        "glob-hasher-win32-arm64-msvc": "1.4.2",
+        "glob-hasher-win32-x64-msvc": "1.4.2"
       }
     },
     "node_modules/glob-hasher-darwin-arm64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/glob-hasher-darwin-arm64/-/glob-hasher-darwin-arm64-1.3.0.tgz",
-      "integrity": "sha512-xJk+chXLeVBamYQ2fo1Plk0uqoUkv42o7PYZBVr7lSy9eoBAqXKCcf23godpA1BoUfz2cWpvzhI0Nl+MQsJX6g==",
+      "version": "1.4.2",
+      "resolved": "http://localhost:4873/glob-hasher-darwin-arm64/-/glob-hasher-darwin-arm64-1.4.2.tgz",
+      "integrity": "sha512-zqCZDkDrgo86UsEbOV5wnfyAVlNQ85clGt9EV4LlskDmv2aeuHD6dFYU8hLbbQSC7nvd90EWewy1WqvV6KsL7A==",
       "cpu": [
         "arm64"
       ],
@@ -2993,9 +3066,9 @@
       }
     },
     "node_modules/glob-hasher-darwin-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/glob-hasher-darwin-x64/-/glob-hasher-darwin-x64-1.3.0.tgz",
-      "integrity": "sha512-RpXjO136MYGi+GyQgYgDqsBmyrLUhSJTwsEZx8mhF/3JcH5/RW/RVhr9PSB9Mt/FU1MH099Ln03G+u3OEDK46g==",
+      "version": "1.4.2",
+      "resolved": "http://localhost:4873/glob-hasher-darwin-x64/-/glob-hasher-darwin-x64-1.4.2.tgz",
+      "integrity": "sha512-yEmIQyr6pGj2RG6IxUpOiVbbTm+lw5+L6MqxdPJvp+Z96YSUIo7aOkru0M8lgFGTRh5fQNDWdoHM6kgK8USYrA==",
       "cpu": [
         "x64"
       ],
@@ -3009,9 +3082,9 @@
       }
     },
     "node_modules/glob-hasher-linux-x64-gnu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/glob-hasher-linux-x64-gnu/-/glob-hasher-linux-x64-gnu-1.3.0.tgz",
-      "integrity": "sha512-B8woNLpg+JEdyD9Lfqvmm0rWDn2aYrh04SthIw2i1hdXwBm53JgsNIcdMnkhW9ZZtRI8LH5uTcQgPmC46lCE4w==",
+      "version": "1.4.2",
+      "resolved": "http://localhost:4873/glob-hasher-linux-x64-gnu/-/glob-hasher-linux-x64-gnu-1.4.2.tgz",
+      "integrity": "sha512-7TT8Wfkw41zwfvkbZJ3M3QqWR4bR9qLnbSzcMFHrOIpJjdnvKzCzrqfi470S8sPb6dyEVyS7s49eP5YB8cSy5A==",
       "cpu": [
         "x64"
       ],
@@ -3025,9 +3098,9 @@
       }
     },
     "node_modules/glob-hasher-win32-arm64-msvc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/glob-hasher-win32-arm64-msvc/-/glob-hasher-win32-arm64-msvc-1.3.0.tgz",
-      "integrity": "sha512-mndlrg8lgXoHjzZooHh5aBkS5vOKRzVYBQkNKhqXmeSK6uV4VPnDYE3I/G7ucyNJc1CcAjQ9YTktwXNJkshLVg==",
+      "version": "1.4.2",
+      "resolved": "http://localhost:4873/glob-hasher-win32-arm64-msvc/-/glob-hasher-win32-arm64-msvc-1.4.2.tgz",
+      "integrity": "sha512-HyNotx1CF0/7ulND7CnbLoyuykGeMIARJRzJK36WlcgR+BqkSfcPJEbsbk7AsHhaBOtlUWAbEX9MDndcx8uguQ==",
       "cpu": [
         "arm64"
       ],
@@ -3041,9 +3114,9 @@
       }
     },
     "node_modules/glob-hasher-win32-x64-msvc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/glob-hasher-win32-x64-msvc/-/glob-hasher-win32-x64-msvc-1.3.0.tgz",
-      "integrity": "sha512-Gs4y0ZX4bJzLA2F9zAafvUJEZEEYYEDREEhdec3KB+a3pPxxjlVtNgH0hVOgXfzv8WRqUdFIff7a1vyem+y2NQ==",
+      "version": "1.4.2",
+      "resolved": "http://localhost:4873/glob-hasher-win32-x64-msvc/-/glob-hasher-win32-x64-msvc-1.4.2.tgz",
+      "integrity": "sha512-6mKybe2NwFABUA7ZxiiXurD5RXDrrCWwGA53NasfnO4z+hvH5q4jG6YvVhavf6GdTapJi9WwfMHRKvoSQNUxeQ==",
       "cpu": [
         "x64"
       ],
@@ -3512,15 +3585,25 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "3.14.1",
+      "resolved": "http://localhost:4873/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "dependencies": {
-        "argparse": "^2.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "http://localhost:4873/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/jsesc": {
@@ -3552,37 +3635,26 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/lage": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/lage/-/lage-2.7.14.tgz",
-      "integrity": "sha512-YHEA3i16GdFlE7TciWfD+a3LtYHLp583qxfm5AVjj/oVzRnTqepvA9DKIne3TVHhtXe3Wqi1D/8NHq9ofElWNA==",
+      "version": "2.12.19",
+      "resolved": "http://localhost:4873/lage/-/lage-2.12.19.tgz",
+      "integrity": "sha512-NlGkO1JojejlR8HzeAZ3sNDOeqazAtsVIE6XLl4Nqw0cUO5JSdcg48a4xwEnRL44JR5Mbk+MREuwoIYRS+19Fg==",
       "dev": true,
       "dependencies": {
-        "glob-hasher": "^1.3.0"
+        "glob-hasher": "^1.4.2"
       },
       "bin": {
-        "lage": "dist/lage.js"
+        "lage": "dist/lage.js",
+        "lage-server": "dist/lage-server.js"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/lines-and-columns": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "version": "2.0.3",
+      "resolved": "http://localhost:4873/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
+      "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -3723,7 +3795,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "http://localhost:4873/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "engines": {
@@ -3732,7 +3804,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "http://localhost:4873/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "dependencies": {
@@ -4108,44 +4180,44 @@
       }
     },
     "node_modules/nx": {
-      "version": "19.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.0.0-beta.8.tgz",
-      "integrity": "sha512-ZPO6lch8IfDg8oB/ArjH8zRASyXgJHvUcpyQ8FGhw/DFtadySG9bYBs+yjaP2+RrfFjW6fmaN7pl6QQU8MmZLg==",
+      "version": "20.5.0-beta.2",
+      "resolved": "http://localhost:4873/nx/-/nx-20.5.0-beta.2.tgz",
+      "integrity": "sha512-5Cj4/dnV+GAgwxRazkj5OYARWGCJJDElns9Y3C/V2TivfkyTF54fGMZGkDHPhQ4/X99A9QECIE7Y6oUdY01L2A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@nrwl/tao": "19.0.0-beta.8",
+        "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.6",
-        "axios": "^1.6.0",
+        "@yarnpkg/parsers": "3.0.2",
+        "@zkochan/js-yaml": "0.0.7",
+        "axios": "^1.7.4",
         "chalk": "^4.1.0",
         "cli-cursor": "3.1.0",
         "cli-spinners": "2.6.1",
         "cliui": "^8.0.1",
-        "dotenv": "~16.3.1",
-        "dotenv-expand": "~10.0.0",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
         "enquirer": "~2.3.6",
         "figures": "3.2.0",
         "flat": "^5.0.2",
-        "fs-extra": "^11.1.0",
+        "front-matter": "^4.0.2",
         "ignore": "^5.0.4",
         "jest-diff": "^29.4.1",
-        "js-yaml": "4.1.0",
         "jsonc-parser": "3.2.0",
-        "lines-and-columns": "~2.0.3",
+        "lines-and-columns": "2.0.3",
         "minimatch": "9.0.3",
         "node-machine-id": "1.1.12",
         "npm-run-path": "^4.0.1",
         "open": "^8.4.0",
         "ora": "5.3.0",
+        "resolve.exports": "2.0.3",
         "semver": "^7.5.3",
         "string-width": "^4.2.3",
-        "strong-log-transformer": "^2.1.0",
         "tar-stream": "~2.2.0",
         "tmp": "~0.2.1",
         "tsconfig-paths": "^4.1.2",
         "tslib": "^2.3.0",
+        "yaml": "^2.6.0",
         "yargs": "^17.6.2",
         "yargs-parser": "21.1.1"
       },
@@ -4154,16 +4226,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "19.0.0-beta.8",
-        "@nx/nx-darwin-x64": "19.0.0-beta.8",
-        "@nx/nx-freebsd-x64": "19.0.0-beta.8",
-        "@nx/nx-linux-arm-gnueabihf": "19.0.0-beta.8",
-        "@nx/nx-linux-arm64-gnu": "19.0.0-beta.8",
-        "@nx/nx-linux-arm64-musl": "19.0.0-beta.8",
-        "@nx/nx-linux-x64-gnu": "19.0.0-beta.8",
-        "@nx/nx-linux-x64-musl": "19.0.0-beta.8",
-        "@nx/nx-win32-arm64-msvc": "19.0.0-beta.8",
-        "@nx/nx-win32-x64-msvc": "19.0.0-beta.8"
+        "@nx/nx-darwin-arm64": "20.5.0-beta.2",
+        "@nx/nx-darwin-x64": "20.5.0-beta.2",
+        "@nx/nx-freebsd-x64": "20.5.0-beta.2",
+        "@nx/nx-linux-arm-gnueabihf": "20.5.0-beta.2",
+        "@nx/nx-linux-arm64-gnu": "20.5.0-beta.2",
+        "@nx/nx-linux-arm64-musl": "20.5.0-beta.2",
+        "@nx/nx-linux-x64-gnu": "20.5.0-beta.2",
+        "@nx/nx-linux-x64-musl": "20.5.0-beta.2",
+        "@nx/nx-win32-arm64-msvc": "20.5.0-beta.2",
+        "@nx/nx-win32-x64-msvc": "20.5.0-beta.2"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -4505,7 +4577,7 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "resolved": "http://localhost:4873/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
@@ -4668,6 +4740,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "http://localhost:4873/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/restore-cursor": {
@@ -4835,7 +4916,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://localhost:4873/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
@@ -4933,23 +5014,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/strong-log-transformer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
-      "integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
-      "dev": true,
-      "dependencies": {
-        "duplexer": "^0.1.1",
-        "minimist": "^1.2.0",
-        "through": "^2.3.4"
-      },
-      "bin": {
-        "sl-log-transformer": "bin/sl-log-transformer.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/styled-jsx": {
       "version": "5.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0-beta.3.tgz",
@@ -5032,12 +5096,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
     },
     "node_modules/ticket-booking": {
       "resolved": "apps/ticket-booking",
@@ -5196,9 +5254,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "http://localhost:4873/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
     "node_modules/tty-browserify": {
@@ -5207,26 +5265,26 @@
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
     },
     "node_modules/turbo": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.3.tgz",
-      "integrity": "sha512-n17HJv4F4CpsYTvKzUJhLbyewbXjq1oLCi90i5tW1TiWDz16ML1eDG7wi5dHaKxzh5efIM56SITnuVbMq5dk4g==",
+      "version": "2.4.1",
+      "resolved": "http://localhost:4873/turbo/-/turbo-2.4.1.tgz",
+      "integrity": "sha512-XIIHXAhvD3sv34WLaN/969WTHCHYmm3zf0XQ+CrEP1A7ffIQG50cwNcp7Gh96CaGyjEXMh9odoHyggoZQ3Prvw==",
       "dev": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.13.3",
-        "turbo-darwin-arm64": "1.13.3",
-        "turbo-linux-64": "1.13.3",
-        "turbo-linux-arm64": "1.13.3",
-        "turbo-windows-64": "1.13.3",
-        "turbo-windows-arm64": "1.13.3"
+        "turbo-darwin-64": "2.4.1",
+        "turbo-darwin-arm64": "2.4.1",
+        "turbo-linux-64": "2.4.1",
+        "turbo-linux-arm64": "2.4.1",
+        "turbo-windows-64": "2.4.1",
+        "turbo-windows-arm64": "2.4.1"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.3.tgz",
-      "integrity": "sha512-glup8Qx1qEFB5jerAnXbS8WrL92OKyMmg5Hnd4PleLljAeYmx+cmmnsmLT7tpaVZIN58EAAwu8wHC6kIIqhbWA==",
+      "version": "2.4.1",
+      "resolved": "http://localhost:4873/turbo-darwin-64/-/turbo-darwin-64-2.4.1.tgz",
+      "integrity": "sha512-oos3Gz5N6ol2/7+ys0wPENhl7ZzeVKIumn2BR7X2oE5dEPxNPDMOpKBwreU9ToCxM94e+uFTzKgjcUJpBqpTHA==",
       "cpu": [
         "x64"
       ],
@@ -5237,9 +5295,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.3.tgz",
-      "integrity": "sha512-/np2xD+f/+9qY8BVtuOQXRq5f9LehCFxamiQnwdqWm5iZmdjygC5T3uVSYuagVFsZKMvX3ycySwh8dylGTl6lg==",
+      "version": "2.4.1",
+      "resolved": "http://localhost:4873/turbo-darwin-arm64/-/turbo-darwin-arm64-2.4.1.tgz",
+      "integrity": "sha512-NoIQsSSvCJDTShgX+v+doSP/g0kAhHhq5p2fpsEAlougs2wcQvwv/LndeqojzkHbxB39lOQmqBYHJcki46Q3oQ==",
       "cpu": [
         "arm64"
       ],
@@ -5250,9 +5308,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.3.tgz",
-      "integrity": "sha512-G+HGrau54iAnbXLfl+N/PynqpDwi/uDzb6iM9hXEDG+yJnSJxaHMShhOkXYJPk9offm9prH33Khx2scXrYVW1g==",
+      "version": "2.4.1",
+      "resolved": "http://localhost:4873/turbo-linux-64/-/turbo-linux-64-2.4.1.tgz",
+      "integrity": "sha512-iXIeG8YhluaJF/5KQEudRf8ECBWND8X0yxXDrFIq2wmLLCg4A7gSSzVcBq30rYYeyyU4xMj/sm3HbsAaao3jjg==",
       "cpu": [
         "x64"
       ],
@@ -5263,9 +5321,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.3.tgz",
-      "integrity": "sha512-qWwEl5VR02NqRyl68/3pwp3c/olZuSp+vwlwrunuoNTm6JXGLG5pTeme4zoHNnk0qn4cCX7DFrOboArlYxv0wQ==",
+      "version": "2.4.1",
+      "resolved": "http://localhost:4873/turbo-linux-arm64/-/turbo-linux-arm64-2.4.1.tgz",
+      "integrity": "sha512-jd5apBV7lBGn3CnkQN/hEMbwazNgZcrwLt6DIkWy/TSi5xfSQEqcR3k9HxviQ7hKMcr1Q1hN6FHWm8Vw90Ej4A==",
       "cpu": [
         "arm64"
       ],
@@ -5276,9 +5334,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.3.tgz",
-      "integrity": "sha512-Nudr4bRChfJzBPzEmpVV85VwUYRCGKecwkBFpbp2a4NtrJ3+UP1VZES653ckqCu2FRyRuS0n03v9euMbAvzH+Q==",
+      "version": "2.4.1",
+      "resolved": "http://localhost:4873/turbo-windows-64/-/turbo-windows-64-2.4.1.tgz",
+      "integrity": "sha512-4RYRAijohyQ7uetZY4SSikSgGccq+7tmnljdm/XezpK9t0+3gldKA2vHF0++yLZeZr+CFgqmBeGSFi7B+vhc2g==",
       "cpu": [
         "x64"
       ],
@@ -5289,9 +5347,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.3.tgz",
-      "integrity": "sha512-ouJCgsVLd3icjRLmRvHQDDZnmGzT64GBupM1Y+TjtYn2LVaEBoV6hicFy8x5DUpnqdLy+YpCzRMkWlwhmkX7sQ==",
+      "version": "2.4.1",
+      "resolved": "http://localhost:4873/turbo-windows-arm64/-/turbo-windows-arm64-2.4.1.tgz",
+      "integrity": "sha512-4lZB0+AxWB01Adx5xHZhO746FgaHR0T3qzEDF2nf/nx8LAUtN3iwaZQgAsTsblaAKjiM7lxWDI0s/Q3fektsPg==",
       "cpu": [
         "arm64"
       ],
@@ -5310,31 +5368,22 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "5.7.3",
+      "resolved": "http://localhost:4873/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -5561,6 +5610,18 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "http://localhost:4873/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "benchmark-no-daemon": "node benchmark.js no-daemon"
   },
   "devDependencies": {
-    "nx": "19.0.0-beta.8",
-    "lage": "2.7.14",
-    "turbo": "1.13.3",
-    "typescript": "4.5.2"
+    "nx": "20.5.0-beta.2",
+    "lage": "2.12.19",
+    "turbo": "2.4.1",
+    "typescript": "5.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "large-monorepo",
   "version": "1.0.0",
   "private": true,
+  "packageManager": "npm@10.9.2",
   "workspaces": [
     "apps/*",
     "packages/*/*"

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "pipeline": {
+  "tasks": {
     "build": {},
     "crew#build": {
       "outputs": [


### PR DESCRIPTION
This PR update all packages to their latest versions, and bumps Node to v22. Also re-run the benchmarks and updated the README.